### PR TITLE
[WEBDEV-800] Remove redundant question data from person_by_id query

### DIFF
--- a/Parliament.Data.Api.FixedQuery/Sparql/person_by_id.sparql
+++ b/Parliament.Data.Api.FixedQuery/Sparql/person_by_id.sparql
@@ -8,7 +8,6 @@ CONSTRUCT {
         :personFamilyName ?familyName ;
         <http://example.com/F31CBD81AD8343898B49DC65743F0BDF> ?displayAs ;
         <http://example.com/D79B0BAC513C4A9A87C9D5AFF1FC632F> ?fullTitle ;
-        :askingPersonHasQuestion ?question ;
         :memberHasMemberImage ?image ;
         :partyMemberHasPartyMembership ?partyMembership ;
         :memberHasParliamentaryIncumbency ?incumbency ;
@@ -110,29 +109,6 @@ CONSTRUCT {
     ?oppositionPosition
         a :OppositionPosition ;
         :positionName ?positionName ;
-    .
-    ?question
-        a :Question ;
-        :questionAskedAt ?questionAskedAt ;
-        :questionHasAnsweringBodyAllocation ?answeringBodyAllocation ;
-        :indexingAndSearchUri ?idmsUri ;
-        :questionHeading ?questionHeading ;
-        :questionHasAnswer ?answer ;
-    .
-    ?answer
-        a :Answer ;
-    .
-    ?answeringBodyAllocation
-        a :AnsweringBodyAllocation ;
-        :answeringBodyAllocationHasAnsweringBody ?answeringBody ;
-    .
-    ?answeringBody
-        a :Group ;
-        :groupName ?groupName ;
-    .
-    ?answeringBody2
-        a :Group ;
-        :groupName ?groupName ;
     .
 }
 WHERE {
@@ -252,46 +228,5 @@ WHERE {
 
         FILTER (!REGEX(STR(?personalWebLink), "facebook")) .
         FILTER (!REGEX(STR(?personalWebLink), "twitter")) .
-    }
-
-    OPTIONAL {
-        {
-            SELECT ?question ?questionAskedAt
-            WHERE {
-                BIND(@person_id AS ?askingPerson)
-
-                ?askingPerson :askingPersonHasQuestion ?question .
-                ?question :indexingAndSearchUri ?idmsUri .
-
-                OPTIONAL { ?question :questionAskedAt ?questionAskedAt . }
-            }
-            ORDER BY DESC(?questionAskedAt)
-            LIMIT 1
-            OFFSET 0
-        }
-
-        OPTIONAL { ?question :questionHeading ?questionHeading . }
-        OPTIONAL {
-            ?question :questionHasAnsweringBodyAllocation ?answeringBodyAllocation .
-            ?answeringBodyAllocation
-                a :AnsweringBodyAllocation ;
-                :answeringBodyAllocationHasAnsweringBody ?answeringBody ;
-            .
-            ?answeringBody a :Group .
-
-            OPTIONAL { ?answeringBody :groupName ?groupName . }
-        }
-        OPTIONAL {
-            ?question :questionHasAnswer ?answer .
-            ?answer
-                a :Answer ;
-                a ?class ;
-                :answerGivenDate ?answerGivenDate ;
-                :answerHasAnsweringBody ?answeringBody2 .
-                ?answeringBody2 a :Group ;
-            .
-
-            OPTIONAL { ?answeringBody2 :groupName ?groupName . }
-        }
     }
 }


### PR DESCRIPTION
Currently, we are pulling all questions and answers into a person show page - this is not needed for the current implementation and in a number of edge cases will cause a given person's page to time out.

In future, we will pull back a sub-set of questions if this feature is introduced again.